### PR TITLE
fix ZEN path formatter to load additional years

### DIFF
--- a/src/netcdf.jl
+++ b/src/netcdf.jl
@@ -136,11 +136,11 @@ load_variable(formatter::Function, basepath::String, name::String, varname::Stri
         for i in 2:length(years)
             if years[i] in [1900:4:2100;]
                 formatter = (n) -> "$(n)/$(n)_leap.nc"  
-                path = joinpath(basepath, formatter(name, years[i]))
+                path = joinpath(basepath, formatter(name))
                 push!(years_vector, get_yeardata(path, varname))
             else
                 formatter = (n) -> "$(n)/$(n).nc"  
-                path = joinpath(basepath, formatter(name, years[i]))
+                path = joinpath(basepath, formatter(name))
                 push!(years_vector, get_yeardata(path, varname))
             end
         end


### PR DESCRIPTION
Hi Raf,

I found an issue with loading more than one year for zenith angle layers. I've fixed it by removing the year from the formatter.

I hope this is fine :)

Urtzi